### PR TITLE
不应显示历史消息日志

### DIFF
--- a/src/puppet-wechat4u.ts
+++ b/src/puppet-wechat4u.ts
@@ -414,7 +414,7 @@ export class PuppetWechat4u extends PUPPET.Puppet {
       }
       // 如果是消息的创建时间小于机器人启动的时间 直接丢弃
       if (msg.CreateTime < this.startTime) {
-        //log.warn('PuppetWechat4u', 'initHookEvents() wechat4u.on(message) is history message: %s', JSON.stringify(msg))
+        // log.warn('PuppetWechat4u', 'initHookEvents() wechat4u.on(message) is history message: %s', JSON.stringify(msg))
         return
       }
       this.cacheMessageRawPayload.set(msg.MsgId, msg)

--- a/src/puppet-wechat4u.ts
+++ b/src/puppet-wechat4u.ts
@@ -414,7 +414,7 @@ export class PuppetWechat4u extends PUPPET.Puppet {
       }
       // 如果是消息的创建时间小于机器人启动的时间 直接丢弃
       if (msg.CreateTime < this.startTime) {
-        log.warn('PuppetWechat4u', 'initHookEvents() wechat4u.on(message) is history message: %s', JSON.stringify(msg))
+        //log.warn('PuppetWechat4u', 'initHookEvents() wechat4u.on(message) is history message: %s', JSON.stringify(msg))
         return
       }
       this.cacheMessageRawPayload.set(msg.MsgId, msg)


### PR DESCRIPTION
每次通过pm2平滑重启时，都会在屏幕上输出很长很长的历史消息日志，非常影响正常日志的查看，考虑到这些消息之前已经输出过日志了，因此重启时不显示更为合理