### PR TITLE
Fix voice msg error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-wechat4u",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "Wechat4u Puppet for Wechaty",
   "type": "module",
   "exports": {

--- a/src/puppet-wechat4u.ts
+++ b/src/puppet-wechat4u.ts
@@ -18,7 +18,6 @@
  */
 import Wechat4u from 'wechat4u'
 import QuickLru from '@alloc/quick-lru'
-import * as XMLParser from 'fast-xml-parser'
 import * as PUPPET from 'wechaty-puppet'
 import { log } from 'wechaty-puppet'
 import type { FileBoxInterface } from 'file-box'
@@ -677,14 +676,7 @@ export class PuppetWechat4u extends PUPPET.Puppet {
           (await this.wechat4u.getVoice(rawPayload.MsgId)).data,
           `message-${id}-audio.sil`,
         )
-        const options = {
-          attrNodeName: '$',
-          attributeNamePrefix: '',
-          ignoreAttributes: false,
-        }
-
-        const msgXmlObj = XMLParser.parse(rawPayload.Content, options)
-        const voiceLength = parseInt(msgXmlObj.msg.voicemsg.$.voicelength, 10)
+        const voiceLength = rawPayload.VoiceLength
         audioFileBox.metadata = {
           voiceLength,
         }

--- a/src/web-schemas.ts
+++ b/src/web-schemas.ts
@@ -218,7 +218,7 @@ export interface WebMessageRawPayload {
 
   SubMsgType:       WebMessageType, // "msgType":"{{message.MsgType}}",
                                     // "subType":{{message.SubMsgType||0}},"msgId":"{{message.MsgId}}"
-
+  VoiceLength:      number,
   /**
    * Status-es
    */


### PR DESCRIPTION
当消息为语音时，rawPayload.content 最近测试已经不是xml string了，会导致计算voiceLength出错，调试发现voiceLength已经是rawPayload的属性了，直接替换即可